### PR TITLE
EO-49566: Added platform and application teams

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -18,6 +18,6 @@ data "aws_eks_cluster_auth" "this" {
 
 # To Authenticate with ECR Public in eu-east-1
 data "aws_ecrpublic_authorization_token" "token" {
-  provider = aws.oregon
+  provider = aws.virginia
 }
 

--- a/kubernetes/team-riker/limit-range.yaml
+++ b/kubernetes/team-riker/limit-range.yaml
@@ -1,0 +1,23 @@
+apiVersion: 'v1'
+kind: 'LimitRange'
+metadata:
+  name: 'resource-limits'
+  namespace: team-riker
+spec:
+  limits:
+    - type: 'Container'
+      max:
+        cpu: '2'
+        memory: '1Gi'
+      min:
+        cpu: '50m'
+        memory: '4Mi'
+      default:
+        cpu: '300m'
+        memory: '200Mi'
+      defaultRequest:
+        cpu: '200m'
+        memory: '100Mi'
+      maxLimitRequestRatio:
+        cpu: '10'
+

--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@ locals {
 
   name            = basename(path.cwd)
   region          = data.aws_region.current.name
-  cluster_version = "1.24"
+  cluster_version = "1.26"
 
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Required for public ECR where Karpenter artifacts are hosted
 provider "aws" {
-  region = "us-west-2"
-  alias  = "oregon"
+  region = "us-east-1"
+  alias  = "virginia"
 }
 
 provider "kubernetes" {
@@ -56,6 +56,42 @@ module "eks_blueprints" {
       subnet_ids      = module.vpc.private_subnets
     }
   }
+
+  platform_teams = {
+    admin = {
+      users = [
+        data.aws_caller_identity.current.arn
+      ]
+    }
+  }
+
+
+  application_teams = {
+    team-riker = {
+      "labels" = {
+        "appName"     = "riker-team-app",
+        "projectName" = "project-riker",
+        "environment" = "dev",
+        "domain"      = "example",
+        "uuid"        = "example",
+        "billingCode" = "example",
+        "branch"      = "example"
+      }
+      "quota" = {
+        "requests.cpu"    = "10",
+        "requests.memory" = "20Gi",
+        "limits.cpu"      = "30",
+        "limits.memory"   = "50Gi",
+        "pods"            = "15",
+        "secrets"         = "10",
+        "services"        = "10"
+      }
+      ## Manifests Example: we can specify a directory with kubernetes manifests that can be automatically applied in the team-riker namespace.
+      manifests_dir = "./kubernetes/team-riker"
+      users         = [data.aws_caller_identity.current.arn]
+    }
+  }
+
 
   tags = local.tags
 }


### PR DESCRIPTION
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.aws_eks_cluster.cluster will be read during apply
  # (config refers to values not yet known)
 <= data "aws_eks_cluster" "cluster" {
      + arn                       = (known after apply)
      + certificate_authority     = (known after apply)
      + cluster_id                = (known after apply)
      + created_at                = (known after apply)
      + enabled_cluster_log_types = (known after apply)
      + endpoint                  = (known after apply)
      + id                        = (known after apply)
      + identity                  = (known after apply)
      + kubernetes_network_config = (known after apply)
      + name                      = (known after apply)
      + outpost_config            = (known after apply)
      + platform_version          = (known after apply)
      + role_arn                  = (known after apply)
      + status                    = (known after apply)
      + tags                      = (known after apply)
      + version                   = (known after apply)
      + vpc_config                = (known after apply)
    }

  # data.aws_eks_cluster_auth.this will be read during apply
  # (config refers to values not yet known)
 <= data "aws_eks_cluster_auth" "this" {
      + id    = (known after apply)
      + name  = (known after apply)
      + token = (sensitive value)
    }

  # module.eks_blueprints.data.aws_eks_cluster.cluster[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_eks_cluster" "cluster" {
      + arn                       = (known after apply)
      + certificate_authority     = (known after apply)
      + cluster_id                = (known after apply)
      + created_at                = (known after apply)
      + enabled_cluster_log_types = (known after apply)
      + endpoint                  = (known after apply)
      + id                        = (known after apply)
      + identity                  = (known after apply)
      + kubernetes_network_config = (known after apply)
      + name                      = (known after apply)
      + outpost_config            = (known after apply)
      + platform_version          = (known after apply)
      + role_arn                  = (known after apply)
      + status                    = (known after apply)
      + tags                      = (known after apply)
      + version                   = (known after apply)
      + vpc_config                = (known after apply)
    }

  # module.eks_blueprints.data.http.eks_cluster_readiness[0] will be read during apply
  # (config refers to values not yet known)
 <= data "http" "eks_cluster_readiness" {
      + body             = (known after apply)
      + ca_certificate   = (known after apply)
      + id               = (known after apply)
      + response_headers = (known after apply)
      + timeout          = 600
      + url              = (known after apply)
    }

  # module.eks_blueprints.kubernetes_config_map.aws_auth[0] will be created
  + resource "kubernetes_config_map" "aws_auth" {
      + data = (known after apply)
      + id   = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + labels           = {
              + "app.kubernetes.io/created-by" = "terraform-aws-eks-blueprints"
              + "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
            }
          + name             = "aws-auth"
          + namespace        = "kube-system"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.eks_blueprints.module.aws_eks.data.tls_certificate.this[0] will be read during apply
  # (config refers to values not yet known)
 <= data "tls_certificate" "this" {
      + certificates = (known after apply)
      + id           = (known after apply)
      + url          = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks.aws_ec2_tag.cluster_primary_security_group["Blueprint"] will be created
  + resource "aws_ec2_tag" "cluster_primary_security_group" {
      + id          = (known after apply)
      + key         = "Blueprint"
      + resource_id = (known after apply)
      + value       = "eks-blueprints-terraform-workshop"
    }

  # module.eks_blueprints.module.aws_eks.aws_ec2_tag.cluster_primary_security_group["GithubRepo"] will be created
  + resource "aws_ec2_tag" "cluster_primary_security_group" {
      + id          = (known after apply)
      + key         = "GithubRepo"
      + resource_id = (known after apply)
      + value       = "github.com/aws-ia/terraform-aws-eks-blueprints"
    }

  # module.eks_blueprints.module.aws_eks.aws_eks_cluster.this[0] will be created
  + resource "aws_eks_cluster" "this" {
      + arn                       = (known after apply)
      + certificate_authority     = (known after apply)
      + cluster_id                = (known after apply)
      + created_at                = (known after apply)
      + enabled_cluster_log_types = [
          + "api",
          + "audit",
          + "authenticator",
          + "controllerManager",
          + "scheduler",
        ]
      + endpoint                  = (known after apply)
      + id                        = (known after apply)
      + identity                  = (known after apply)
      + name                      = "eks-blueprints-terraform-workshop"
      + platform_version          = (known after apply)
      + role_arn                  = (known after apply)
      + status                    = (known after apply)
      + tags                      = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all                  = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + version                   = "1.26"

      + encryption_config {
          + resources = [
              + "secrets",
            ]

          + provider {
              + key_arn = (known after apply)
            }
        }

      + kubernetes_network_config {
          + ip_family         = "ipv4"
          + service_ipv4_cidr = (known after apply)
          + service_ipv6_cidr = (known after apply)
        }

      + timeouts {}

      + vpc_config {
          + cluster_security_group_id = (known after apply)
          + endpoint_private_access   = false
          + endpoint_public_access    = true
          + public_access_cidrs       = [
              + "0.0.0.0/0",
            ]
          + security_group_ids        = (known after apply)
          + subnet_ids                = [
              + "subnet-0642b32d7e68594b3",
              + "subnet-09c9234b1a7a5d917",
              + "subnet-0e3c27c72c7062884",
            ]
          + vpc_id                    = (known after apply)
        }
    }

  # module.eks_blueprints.module.aws_eks.aws_iam_openid_connect_provider.oidc_provider[0] will be created
  + resource "aws_iam_openid_connect_provider" "oidc_provider" {
      + arn             = (known after apply)
      + client_id_list  = [
          + "sts.amazonaws.com",
        ]
      + id              = (known after apply)
      + tags            = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
          + "Name"       = "eks-blueprints-terraform-workshop-eks-irsa"
        }
      + tags_all        = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
          + "Name"       = "eks-blueprints-terraform-workshop-eks-irsa"
        }
      + thumbprint_list = (known after apply)
      + url             = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks.aws_iam_role.this[0] will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "eks.amazonaws.com"
                        }
                      + Sid       = "EKSClusterAssumeRole"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = true
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "eks-blueprints-terraform-workshop-cluster-role"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + role_last_used        = (known after apply)
      + tags                  = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all              = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + unique_id             = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks.aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"] will be created
  + resource "aws_iam_role_policy_attachment" "this" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
      + role       = "eks-blueprints-terraform-workshop-cluster-role"
    }

  # module.eks_blueprints.module.aws_eks.aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"] will be created
  + resource "aws_iam_role_policy_attachment" "this" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
      + role       = "eks-blueprints-terraform-workshop-cluster-role"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group.cluster[0] will be created
  + resource "aws_security_group" "cluster" {
      + arn                    = (known after apply)
      + description            = "EKS cluster security group"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "eks-blueprints-terraform-workshop-cluster-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
          + "Name"       = "eks-blueprints-terraform-workshop-cluster"
        }
      + tags_all               = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
          + "Name"       = "eks-blueprints-terraform-workshop-cluster"
        }
      + vpc_id                 = "vpc-0c896384adcf2fede"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group.node[0] will be created
  + resource "aws_security_group" "node" {
      + arn                    = (known after apply)
      + description            = "EKS node shared security group"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "eks-blueprints-terraform-workshop-node-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Blueprint"                                               = "eks-blueprints-terraform-workshop"
          + "GithubRepo"                                              = "github.com/aws-ia/terraform-aws-eks-blueprints"
          + "Name"                                                    = "eks-blueprints-terraform-workshop-node"
          + "kubernetes.io/cluster/eks-blueprints-terraform-workshop" = "owned"
        }
      + tags_all               = {
          + "Blueprint"                                               = "eks-blueprints-terraform-workshop"
          + "GithubRepo"                                              = "github.com/aws-ia/terraform-aws-eks-blueprints"
          + "Name"                                                    = "eks-blueprints-terraform-workshop-node"
          + "kubernetes.io/cluster/eks-blueprints-terraform-workshop" = "owned"
        }
      + vpc_id                 = "vpc-0c896384adcf2fede"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.cluster["egress_nodes_443"] will be created
  + resource "aws_security_group_rule" "cluster" {
      + description              = "Cluster API to node groups"
      + from_port                = 443
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.cluster["egress_nodes_kubelet"] will be created
  + resource "aws_security_group_rule" "cluster" {
      + description              = "Cluster API to node kubelets"
      + from_port                = 10250
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 10250
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.cluster["ingress_nodes_443"] will be created
  + resource "aws_security_group_rule" "cluster" {
      + description              = "Node groups to cluster API"
      + from_port                = 443
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_cluster_443"] will be created
  + resource "aws_security_group_rule" "node" {
      + description              = "Node groups to cluster API"
      + from_port                = 443
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_https"] will be created
  + resource "aws_security_group_rule" "node" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Egress all HTTPS to internet"
      + from_port                = 443
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_ntp_tcp"] will be created
  + resource "aws_security_group_rule" "node" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Egress NTP/TCP to internet"
      + from_port                = 123
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 123
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_ntp_udp"] will be created
  + resource "aws_security_group_rule" "node" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Egress NTP/UDP to internet"
      + from_port                = 123
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "udp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 123
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_self_coredns_tcp"] will be created
  + resource "aws_security_group_rule" "node" {
      + description              = "Node to node CoreDNS"
      + from_port                = 53
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = true
      + source_security_group_id = (known after apply)
      + to_port                  = 53
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_self_coredns_udp"] will be created
  + resource "aws_security_group_rule" "node" {
      + description              = "Node to node CoreDNS"
      + from_port                = 53
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "udp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = true
      + source_security_group_id = (known after apply)
      + to_port                  = 53
      + type                     = "egress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_cluster_443"] will be created
  + resource "aws_security_group_rule" "node" {
      + description              = "Cluster API to node groups"
      + from_port                = 443
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_cluster_kubelet"] will be created
  + resource "aws_security_group_rule" "node" {
      + description              = "Cluster API to node kubelets"
      + from_port                = 10250
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 10250
      + type                     = "ingress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_self_coredns_tcp"] will be created
  + resource "aws_security_group_rule" "node" {
      + description              = "Node to node CoreDNS"
      + from_port                = 53
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = true
      + source_security_group_id = (known after apply)
      + to_port                  = 53
      + type                     = "ingress"
    }

  # module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_self_coredns_udp"] will be created
  + resource "aws_security_group_rule" "node" {
      + description              = "Node to node CoreDNS"
      + from_port                = 53
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "udp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = true
      + source_security_group_id = (known after apply)
      + to_port                  = 53
      + type                     = "ingress"
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].data.aws_iam_policy_document.managed_ng_assume_role_policy will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "managed_ng_assume_role_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions = [
              + "sts:AssumeRole",
            ]
          + sid     = "EKSWorkerAssumeRole"

          + principals {
              + identifiers = [
                  + "ec2.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_eks_node_group.managed_ng will be created
  + resource "aws_eks_node_group" "managed_ng" {
      + ami_type               = "AL2_x86_64"
      + arn                    = (known after apply)
      + capacity_type          = "ON_DEMAND"
      + cluster_name           = (known after apply)
      + disk_size              = 50
      + id                     = (known after apply)
      + instance_types         = [
          + "t2.medium",
        ]
      + node_group_name        = (known after apply)
      + node_group_name_prefix = "managed-ondemand-"
      + node_role_arn          = (known after apply)
      + release_version        = (known after apply)
      + resources              = (known after apply)
      + status                 = (known after apply)
      + subnet_ids             = [
          + "subnet-0642b32d7e68594b3",
          + "subnet-09c9234b1a7a5d917",
          + "subnet-0e3c27c72c7062884",
        ]
      + tags                   = (known after apply)
      + tags_all               = (known after apply)
      + version                = "1.26"

      + scaling_config {
          + desired_size = 3
          + max_size     = 3
          + min_size     = 1
        }

      + timeouts {
          + create = "30m"
          + delete = "30m"
          + update = "2h"
        }

      + update_config {
          + max_unavailable = 1
        }
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_instance_profile.managed_ng[0] will be created
  + resource "aws_iam_instance_profile" "managed_ng" {
      + arn         = (known after apply)
      + create_date = (known after apply)
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = (known after apply)
      + path        = "/"
      + role        = (known after apply)
      + tags        = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all    = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + unique_id   = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role.managed_ng[0] will be created
  + resource "aws_iam_role" "managed_ng" {
      + arn                   = (known after apply)
      + assume_role_policy    = (known after apply)
      + create_date           = (known after apply)
      + description           = "EKS Managed Node group IAM Role"
      + force_detach_policies = true
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = (known after apply)
      + path                  = "/"
      + role_last_used        = (known after apply)
      + tags                  = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all              = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + unique_id             = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"] will be created
  + resource "aws_iam_role_policy_attachment" "managed_ng" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
      + role       = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"] will be created
  + resource "aws_iam_role_policy_attachment" "managed_ng" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
      + role       = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"] will be created
  + resource "aws_iam_role_policy_attachment" "managed_ng" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
      + role       = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"] will be created
  + resource "aws_iam_role_policy_attachment" "managed_ng" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
      + role       = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_teams[0].data.aws_eks_cluster.eks_cluster will be read during apply
  # (config refers to values not yet known)
 <= data "aws_eks_cluster" "eks_cluster" {
      + arn                       = (known after apply)
      + certificate_authority     = (known after apply)
      + cluster_id                = (known after apply)
      + created_at                = (known after apply)
      + enabled_cluster_log_types = (known after apply)
      + endpoint                  = (known after apply)
      + id                        = (known after apply)
      + identity                  = (known after apply)
      + kubernetes_network_config = (known after apply)
      + name                      = (known after apply)
      + outpost_config            = (known after apply)
      + platform_version          = (known after apply)
      + role_arn                  = (known after apply)
      + status                    = (known after apply)
      + tags                      = (known after apply)
      + version                   = (known after apply)
      + vpc_config                = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_teams[0].data.aws_iam_policy_document.platform_team_eks_access[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "platform_team_eks_access" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "eks:AccessKubernetesApi",
              + "eks:DescribeCluster",
              + "eks:DescribeNodegroup",
              + "eks:ListClusters",
              + "eks:ListFargateProfiles",
              + "eks:ListNodegroups",
              + "eks:ListUpdates",
              + "ssm:GetParameter",
            ]
          + resources = [
              + (known after apply),
            ]
          + sid       = "AllowPlatformTeamEKSAccess"
        }
      + statement {
          + actions   = [
              + "eks:ListClusters",
            ]
          + resources = [
              + "*",
            ]
          + sid       = "AllowListClusters"
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].aws_iam_policy.platform_team_eks_access[0] will be created
  + resource "aws_iam_policy" "platform_team_eks_access" {
      + arn         = (known after apply)
      + description = "Platform Team EKS Console Access"
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = (known after apply)
      + policy_id   = (known after apply)
      + tags        = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all    = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].aws_iam_role.platform_team["admin"] will be created
  + resource "aws_iam_role" "platform_team" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:sts::860602188711:assumed-role/AWSReservedSSO_AdministratorAccess_cba8f873db8c16f0/ust-divya-mathew",
                            ]
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = (known after apply)
      + path                  = "/"
      + role_last_used        = (known after apply)
      + tags                  = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all              = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + unique_id             = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_teams[0].aws_iam_role.team_access["team-riker"] will be created
  + resource "aws_iam_role" "team_access" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:sts::860602188711:assumed-role/AWSReservedSSO_AdministratorAccess_cba8f873db8c16f0/ust-divya-mathew",
                            ]
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = (known after apply)
      + path                  = "/"
      + role_last_used        = (known after apply)
      + tags                  = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all              = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + unique_id             = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_teams[0].aws_iam_role.team_sa_irsa["team-riker"] will be created
  + resource "aws_iam_role" "team_sa_irsa" {
      + arn                   = (known after apply)
      + assume_role_policy    = (known after apply)
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = (known after apply)
      + path                  = "/"
      + role_last_used        = (known after apply)
      + tags                  = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all              = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + unique_id             = (known after apply)
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubectl_manifest.team["kubernetes/team-riker/limit-range.yaml"] will be created
  + resource "kubectl_manifest" "team" {
      + api_version             = "v1"
      + apply_only              = false
      + force_conflicts         = false
      + force_new               = false
      + id                      = (known after apply)
      + kind                    = "LimitRange"
      + live_manifest_incluster = (sensitive value)
      + live_uid                = (known after apply)
      + name                    = "resource-limits"
      + namespace               = "team-riker"
      + server_side_apply       = false
      + uid                     = (known after apply)
      + validate_schema         = true
      + wait_for_rollout        = true
      + yaml_body               = (sensitive value)
      + yaml_body_parsed        = <<-EOT
            apiVersion: v1
            kind: LimitRange
            metadata:
              name: resource-limits
              namespace: team-riker
            spec:
              limits:
              - default:
                  cpu: 300m
                  memory: 200Mi
                defaultRequest:
                  cpu: 200m
                  memory: 100Mi
                max:
                  cpu: "2"
                  memory: 1Gi
                maxLimitRequestRatio:
                  cpu: "10"
                min:
                  cpu: 50m
                  memory: 4Mi
                type: Container
        EOT
      + yaml_incluster          = (sensitive value)
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubernetes_cluster_role.team["team-riker"] will be created
  + resource "kubernetes_cluster_role" "team" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "team-riker-team-cluster-role"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }

      + rule {
          + api_groups = [
              + "",
            ]
          + resources  = [
              + "namespaces",
              + "nodes",
            ]
          + verbs      = [
              + "get",
              + "list",
              + "watch",
            ]
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubernetes_cluster_role_binding.team["team-riker"] will be created
  + resource "kubernetes_cluster_role_binding" "team" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "team-riker-team-cluster-role-binding"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }

      + role_ref {
          + api_group = "rbac.authorization.k8s.io"
          + kind      = "ClusterRole"
          + name      = "team-riker-team-cluster-role"
        }

      + subject {
          + api_group = "rbac.authorization.k8s.io"
          + kind      = "Group"
          + name      = "team-riker-group"
          + namespace = "default"
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubernetes_namespace.team["team-riker"] will be created
  + resource "kubernetes_namespace" "team" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + labels           = {
              + "appName"     = "riker-team-app"
              + "billingCode" = "example"
              + "branch"      = "example"
              + "domain"      = "example"
              + "environment" = "dev"
              + "projectName" = "project-riker"
              + "uuid"        = "example"
            }
          + name             = "team-riker"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubernetes_resource_quota.this["team-riker"] will be created
  + resource "kubernetes_resource_quota" "this" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "quotas"
          + namespace        = "team-riker"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }

      + spec {
          + hard = {
              + "limits.cpu"      = "30"
              + "limits.memory"   = "50Gi"
              + "pods"            = "15"
              + "requests.cpu"    = "10"
              + "requests.memory" = "20Gi"
              + "secrets"         = "10"
              + "services"        = "10"
            }
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubernetes_role.team["team-riker"] will be created
  + resource "kubernetes_role" "team" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "team-riker-role"
          + namespace        = "team-riker"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }

      + rule {
          + api_groups = [
              + "*",
            ]
          + resources  = [
              + "configmaps",
              + "deployments",
              + "horizontalpodautoscalers",
              + "networkpolicies",
              + "pods",
              + "podtemplates",
              + "replicasets",
              + "secrets",
              + "serviceaccounts",
              + "services",
              + "statefulsets",
            ]
          + verbs      = [
              + "get",
              + "list",
              + "watch",
            ]
        }
      + rule {
          + api_groups = [
              + "*",
            ]
          + resources  = [
              + "resourcequotas",
            ]
          + verbs      = [
              + "get",
              + "list",
              + "watch",
            ]
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubernetes_role_binding.team["team-riker"] will be created
  + resource "kubernetes_role_binding" "team" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "team-riker-role-binding"
          + namespace        = "team-riker"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }

      + role_ref {
          + api_group = "rbac.authorization.k8s.io"
          + kind      = "Role"
          + name      = "team-riker-role"
        }

      + subject {
          + api_group = "rbac.authorization.k8s.io"
          + kind      = "Group"
          + name      = "team-riker-group"
          + namespace = "team-riker"
        }
    }

  # module.eks_blueprints.module.aws_eks_teams[0].kubernetes_service_account.team["team-riker"] will be created
  + resource "kubernetes_service_account" "team" {
      + automount_service_account_token = true
      + default_secret_name             = (known after apply)
      + id                              = (known after apply)

      + metadata {
          + annotations      = (known after apply)
          + generation       = (known after apply)
          + name             = "team-riker-sa"
          + namespace        = "team-riker"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.eks_blueprints.module.kms[0].aws_kms_alias.this will be created
  + resource "aws_kms_alias" "this" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/eks-blueprints-terraform-workshop"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.eks_blueprints.module.kms[0].aws_kms_key.this will be created
  + resource "aws_kms_key" "this" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 30
      + description                        = "eks-blueprints-terraform-workshop EKS cluster secret encryption key"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:Encrypt",
                          + "kms:DescribeKey",
                          + "kms:Decrypt",
                          + "kms:CreateGrant",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + "kms:CallerAccount" = "860602188711"
                              + "kms:ViaService"    = "eks.us-west-2.amazonaws.com"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::860602188711:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow access for all principals in the account that are authorized"
                    },
                  + {
                      + Action    = [
                          + "kms:RevokeGrant",
                          + "kms:List*",
                          + "kms:Get*",
                          + "kms:Describe*",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::860602188711:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow direct access to key metadata to the account"
                    },
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::860602188711:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_cba8f873db8c16f0"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow access for Key Administrators"
                    },
                  + {
                      + Action    = [
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:Encrypt",
                          + "kms:DescribeKey",
                          + "kms:Decrypt",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::860602188711:role/eks-blueprints-terraform-workshop-cluster-role"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow use of the key"
                    },
                  + {
                      + Action    = [
                          + "kms:RevokeGrant",
                          + "kms:ListGrants",
                          + "kms:CreateGrant",
                        ]
                      + Condition = {
                          + Bool = {
                              + "kms:GrantIsForAWSResource" = "true"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::860602188711:role/eks-blueprints-terraform-workshop-cluster-role"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow attachment of persistent resources"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + tags                               = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
      + tags_all                           = {
          + "Blueprint"  = "eks-blueprints-terraform-workshop"
          + "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints"
        }
    }

Plan: 44 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + configure_kubectl = (known after apply)

``` 