### PR TITLE
Feature/E0-49574: Connect to the cluster added

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -17,7 +17,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 # To Authenticate with ECR Public in eu-east-1
-data "aws_ecrpublic_authorization_token" "token" {
-  provider = aws.oregon
-}
+ # data "aws_ecrpublic_authorization_token" "token" {
+ # provider = aws.London
+#}
 

--- a/kubernetes/team-riker/limit-range.yaml
+++ b/kubernetes/team-riker/limit-range.yaml
@@ -1,0 +1,23 @@
+apiVersion: 'v1'
+kind: 'LimitRange'
+metadata:
+  name: 'resource-limits'
+  namespace: team-riker
+spec:
+  limits:
+    - type: 'Container'
+      max:
+        cpu: '2'
+        memory: '1Gi'
+      min:
+        cpu: '50m'
+        memory: '4Mi'
+      default:
+        cpu: '300m'
+        memory: '200Mi'
+      defaultRequest:
+        cpu: '200m'
+        memory: '100Mi'
+      maxLimitRequestRatio:
+        cpu: '10'
+

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Required for public ECR where Karpenter artifacts are hosted
 provider "aws" {
-  region = "us-west-2"
-  alias  = "oregon"
+  region = "eu-west-2"
+  alias  = "London"
 }
 
 provider "kubernetes" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,3 +8,14 @@ output "configure_kubectl" {
   value       = module.eks_blueprints.configure_kubectl
 }
 
+output "platform_teams_configure_kubectl" {
+  description = "Configure kubectl for each Platform Team: make sure you're logged in with the correct AWS CLI profile and run the following command to update your kubeconfig"
+  value       = try(module.eks_blueprints.teams[0].platform_teams_configure_kubectl["admin"], null)
+}
+
+output "application_teams_configure_kubectl" {
+  description = "Configure kubectl for each Application Teams: make sure you're logged in with the correct AWS CLI profile and run the following command to update your kubeconfig"
+  value       = try(module.eks_blueprints.teams[0].application_teams_configure_kubectl["team-riker"], null)
+}
+
+


### PR DESCRIPTION
```
module.eks_blueprints.module.aws_eks.module.kms.data.aws_partition.current: Reading...
module.vpc.aws_vpc.this[0]: Refreshing state... [id=vpc-023a17b1b86a4121c]
module.eks_blueprints.data.aws_region.current: Reading...
module.eks_blueprints.module.aws_eks.module.kms.data.aws_caller_identity.current: Reading...
module.eks_blueprints.data.aws_region.current: Read complete after 0s [id=eu-west-2]
data.aws_caller_identity.current: Reading...
module.eks_blueprints.module.aws_eks.module.kms.data.aws_partition.current: Read complete after 0s [id=aws]
module.eks_blueprints.module.aws_eks.data.aws_partition.current: Reading...
data.aws_region.current: Reading...
module.eks_blueprints.data.aws_partition.current: Reading...
module.eks_blueprints.module.aws_eks.data.aws_partition.current: Read complete after 0s [id=aws]
module.eks_blueprints.data.aws_caller_identity.current: Reading...
module.eks_blueprints.module.aws_eks.data.aws_caller_identity.current: Reading...
data.aws_availability_zones.available: Reading...
module.eks_blueprints.data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.current: Read complete after 0s [id=eu-west-2]
module.eks_blueprints.module.aws_eks.data.aws_iam_policy_document.assume_role_policy[0]: Reading...
module.eks_blueprints.module.aws_eks.data.aws_iam_policy_document.assume_role_policy[0]: Read complete after 0s [id=2764486067]
module.eks_blueprints.module.aws_eks.aws_iam_role.this[0]: Refreshing state... [id=eks-blueprints-terraform-workshop-cluster-role]
module.eks_blueprints.module.aws_eks.module.kms.data.aws_caller_identity.current: Read complete after 0s [id=860602188711]
data.aws_caller_identity.current: Read complete after 0s [id=860602188711]
module.eks_blueprints.module.aws_eks.data.aws_caller_identity.current: Read complete after 0s [id=860602188711]
module.eks_blueprints.data.aws_caller_identity.current: Read complete after 0s [id=860602188711]
module.eks_blueprints.data.aws_iam_session_context.current: Reading...
module.eks_blueprints.data.aws_iam_session_context.current: Read complete after 0s [id=arn:aws:sts::860602188711:assumed-role/AWSReservedSSO_AdministratorAccess_cba8f873db8c16f0/ust-divya-mathew]
module.eks_blueprints.data.aws_iam_policy_document.eks_key: Reading...
module.eks_blueprints.data.aws_iam_policy_document.eks_key: Read complete after 0s [id=1303401036]
module.eks_blueprints.module.kms[0].aws_kms_key.this: Refreshing state... [id=61ce322d-a256-4912-82a4-19102b8e91cf]
module.eks_blueprints.module.aws_eks.aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"]: Refreshing state... [id=eks-blueprints-terraform-workshop-cluster-role-20230511034251732400000001]
module.eks_blueprints.module.aws_eks.aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"]: Refreshing state... [id=eks-blueprints-terraform-workshop-cluster-role-20230511034251738000000002]
data.aws_availability_zones.available: Read complete after 0s [id=eu-west-2]
module.vpc.aws_eip.nat[0]: Refreshing state... [id=eipalloc-0785709956e54f51e]
module.eks_blueprints.module.kms[0].aws_kms_alias.this: Refreshing state... [id=alias/eks-blueprints-terraform-workshop]
module.vpc.aws_default_security_group.this[0]: Refreshing state... [id=sg-0200553bfdd3890d4]
module.vpc.aws_route_table.public[0]: Refreshing state... [id=rtb-0ba1533aed197c432]
module.vpc.aws_default_network_acl.this[0]: Refreshing state... [id=acl-0b9dc1394f7ccd324]
module.eks_blueprints.module.aws_eks.aws_security_group.cluster[0]: Refreshing state... [id=sg-0a7af8257bf898cc4]
module.vpc.aws_subnet.public[1]: Refreshing state... [id=subnet-0069a8be35d59a6fc]
module.vpc.aws_route_table.private[0]: Refreshing state... [id=rtb-03ad07a909dd05e33]
module.vpc.aws_subnet.private[0]: Refreshing state... [id=subnet-03637708b9d7dfc52]
module.vpc.aws_default_route_table.default[0]: Refreshing state... [id=rtb-0f8d70a72b5b336be]
module.vpc.aws_subnet.private[1]: Refreshing state... [id=subnet-07a001bf666bc8225]
module.vpc.aws_subnet.private[2]: Refreshing state... [id=subnet-099dc82770998d2e3]
module.vpc.aws_subnet.public[2]: Refreshing state... [id=subnet-0a815eb877e4ad343]
module.vpc.aws_subnet.public[0]: Refreshing state... [id=subnet-023a9c3699ba21089]
module.vpc.aws_internet_gateway.this[0]: Refreshing state... [id=igw-0705b56bca03fe2ff]
module.eks_blueprints.module.aws_eks.aws_security_group.node[0]: Refreshing state... [id=sg-0a6df9856caba5c83]
module.vpc.aws_route_table_association.public[2]: Refreshing state... [id=rtbassoc-0428e1726e3a79891]
module.vpc.aws_route.public_internet_gateway[0]: Refreshing state... [id=r-rtb-0ba1533aed197c4321080289494]
module.vpc.aws_route_table_association.public[1]: Refreshing state... [id=rtbassoc-0b1e3d83b12c36548]
module.vpc.aws_nat_gateway.this[0]: Refreshing state... [id=nat-0fc33eaa2ceddfc9a]
module.vpc.aws_route_table_association.public[0]: Refreshing state... [id=rtbassoc-0b7f777acf82834b4]
module.vpc.aws_route_table_association.private[2]: Refreshing state... [id=rtbassoc-0c0a6d958fcc1d733]
module.vpc.aws_route_table_association.private[1]: Refreshing state... [id=rtbassoc-0a548a752d5df914f]
module.vpc.aws_route_table_association.private[0]: Refreshing state... [id=rtbassoc-00466c21155e925f6]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_cluster_kubelet"]: Refreshing state... [id=sgrule-725912432]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_self_coredns_udp"]: Refreshing state... [id=sgrule-1721684421]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_ntp_tcp"]: Refreshing state... [id=sgrule-3984634257]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_ntp_udp"]: Refreshing state... [id=sgrule-2468254876]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_https"]: Refreshing state... [id=sgrule-845057167]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_self_coredns_tcp"]: Refreshing state... [id=sgrule-3586666165]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_cluster_443"]: Refreshing state... [id=sgrule-3991001411]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_self_coredns_tcp"]: Refreshing state... [id=sgrule-3267457578]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["ingress_cluster_443"]: Refreshing state... [id=sgrule-3978286608]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.node["egress_self_coredns_udp"]: Refreshing state... [id=sgrule-1538239699]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.cluster["egress_nodes_443"]: Refreshing state... [id=sgrule-2951171160]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.cluster["egress_nodes_kubelet"]: Refreshing state... [id=sgrule-1965259151]
module.eks_blueprints.module.aws_eks.aws_security_group_rule.cluster["ingress_nodes_443"]: Refreshing state... [id=sgrule-469812109]
module.vpc.aws_route.private_nat_gateway[0]: Refreshing state... [id=r-rtb-03ad07a909dd05e331080289494]
module.eks_blueprints.module.aws_eks.aws_eks_cluster.this[0]: Refreshing state... [id=eks-blueprints-terraform-workshop]
module.eks_blueprints.module.aws_eks.aws_ec2_tag.cluster_primary_security_group["GithubRepo"]: Refreshing state... [id=sg-0ccadecbc6d76af74,GithubRepo]
module.eks_blueprints.module.aws_eks.data.tls_certificate.this[0]: Reading...
module.eks_blueprints.module.aws_eks.aws_ec2_tag.cluster_primary_security_group["Blueprint"]: Refreshing state... [id=sg-0ccadecbc6d76af74,Blueprint]
module.eks_blueprints.data.aws_eks_cluster.cluster[0]: Reading...
data.aws_eks_cluster.cluster: Reading...
data.aws_eks_cluster_auth.this: Reading...
data.aws_eks_cluster_auth.this: Read complete after 0s [id=eks-blueprints-terraform-workshop]
module.eks_blueprints.data.aws_eks_cluster.cluster[0]: Read complete after 0s [id=eks-blueprints-terraform-workshop]
data.aws_eks_cluster.cluster: Read complete after 0s [id=eks-blueprints-terraform-workshop]
module.eks_blueprints.module.aws_eks.data.tls_certificate.this[0]: Read complete after 0s [id=17bd96401642e610ba843d6cef08c95bfb79f46c]
module.eks_blueprints.data.http.eks_cluster_readiness[0]: Reading...
module.eks_blueprints.module.aws_eks.aws_iam_openid_connect_provider.oidc_provider[0]: Refreshing state... [id=arn:aws:iam::860602188711:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/AF91C8D3212AC2D8190E7DADB978D85E]
module.eks_blueprints.data.http.eks_cluster_readiness[0]: Read complete after 1s [id=https://AF91C8D3212AC2D8190E7DADB978D85E.gr7.eu-west-2.eks.amazonaws.com/healthz]
module.eks_blueprints.kubernetes_config_map.aws_auth[0]: Refreshing state... [id=kube-system/aws-auth]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].data.aws_iam_policy_document.managed_ng_assume_role_policy: Reading...
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].data.aws_iam_policy_document.managed_ng_assume_role_policy: Read complete after 0s [id=3778018924]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role.managed_ng[0]: Refreshing state... [id=eks-blueprints-terraform-workshop-managed-ondemand]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]: Refreshing state... [id=eks-blueprints-terraform-workshop-managed-ondemand-20230512065437016500000007]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]: Refreshing state... [id=eks-blueprints-terraform-workshop-managed-ondemand-20230512065436975400000004]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"]: Refreshing state... [id=eks-blueprints-terraform-workshop-managed-ondemand-20230512065436995100000006]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_role_policy_attachment.managed_ng["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]: Refreshing state... [id=eks-blueprints-terraform-workshop-managed-ondemand-20230512065436993400000005]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_iam_instance_profile.managed_ng[0]: Refreshing state... [id=eks-blueprints-terraform-workshop-managed-ondemand]
module.eks_blueprints.module.aws_eks_managed_node_groups["mg_5"].aws_eks_node_group.managed_ng: Refreshing state... [id=eks-blueprints-terraform-workshop:managed-ondemand-20230512065437325900000008]

No changes. Your infrastructure matches the configuration.


``` 